### PR TITLE
Update GitHub Ubuntu runner image

### DIFF
--- a/.github/workflows/trigger-osv-db-build.yaml
+++ b/.github/workflows/trigger-osv-db-build.yaml
@@ -18,7 +18,7 @@ env:
 jobs:
   test:
     name: Build the new image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out repository code


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.

ref: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/