### PR TITLE
Change schedule to run at 30 minutes past the hour

### DIFF
--- a/.github/workflows/trigger-osv-db-build.yaml
+++ b/.github/workflows/trigger-osv-db-build.yaml
@@ -5,7 +5,7 @@ name: Trigger osv db image build
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '30 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Since MintMaker runs at xx:00, changing schedule to xx:30 will ensure a fresher database.