### PR TITLE
Build OSV database in mintmaker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM quay.io/konflux-ci/mintmaker:latest as tools
+FROM quay.io/konflux-ci/mintmaker:latest as builder
+RUN /osv-generator -destination-dir /tmp/osv-db -container-filename docker.nedb -rpm-filename rpm.nedb -days 120
+RUN rm -f /tmp/osv-db/osv-offline.zip
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
 WORKDIR /
-COPY --from=tools /osv-generator .
-
-RUN /osv-generator -destination-dir /data/osv-db -container-filename docker.nedb -rpm-filename rpm.nedb -days 120
+COPY --from=builder /tmp/osv-db /data/osv-db
 
 # It is mandatory to set these labels
 LABEL name="Konflux Mintmaker OSV database"


### PR DESCRIPTION
mintmaker image has the tool installed, we just need to build the OSV database in mintmaker image, then copy to database image.