### PR TITLE
Remove expires-after label for image build for push event

### DIFF
--- a/.tekton/mintmaker-osv-database-push.yaml
+++ b/.tekton/mintmaker-osv-database-push.yaml
@@ -24,8 +24,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/konflux-mintmaker-tenant/mintmaker-osv-database:{{revision}}
-  - name: image-expires-after
-    value: 5d
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:


### PR DESCRIPTION
By default, we can't release images with `quay.expires-after` label. Remove the label and will check if we do need that label, if yes, we'll try to figure out a solution, e.g., disabling the EC check on this.